### PR TITLE
options not passed in when value is string

### DIFF
--- a/src/DistributedCache.AzureTableStorage/Extensions/DistributedCachingExtensions.cs
+++ b/src/DistributedCache.AzureTableStorage/Extensions/DistributedCachingExtensions.cs
@@ -31,7 +31,7 @@ namespace DistributedCache.AzureTableStorage.Extensions
 
             if (typeof(T) == typeof(string))
             {
-                return distributedCache.SetStringAsync(key, value as string, token);
+                return distributedCache.SetStringAsync(key, value as string, options, token);
             }
 
             return distributedCache.SetAsync(key, BinarySerializer.Serialize(value), options, token);


### PR DESCRIPTION
I happened to have created a test that used a dummy string to check that the cache options were working and discovered this bug.  Options doesn't get passed-in when a string value is used.  Minor, but annoying.