### PR TITLE
Add a default DefaultAbsoluteExpirationRelativeToNow option

### DIFF
--- a/src/DistributedCache.AzureTableStorage/Implementations/AzureTableStorageCache.cs
+++ b/src/DistributedCache.AzureTableStorage/Implementations/AzureTableStorageCache.cs
@@ -32,6 +32,7 @@ namespace DistributedCache.AzureTableStorage.Implementations
         private DateTimeOffset _lastExpirationScan;
         private readonly Func<Task> _deleteExpiredCachedItemsDelegate;
         private readonly string _partitionKey;
+        private readonly TimeSpan? _defaultAbsoluteExpirationRelativeToNow;
         private readonly Lazy<ITableSet<CachedItem>> _tableSet;
 
         /// <summary>
@@ -59,6 +60,7 @@ namespace DistributedCache.AzureTableStorage.Implementations
             _expiredItemsDeletionInterval = cacheOptions.ExpiredItemsDeletionInterval;
             _deleteExpiredCachedItemsDelegate = DeleteExpiredCacheItems;
             _partitionKey = cacheOptions.PartitionKey;
+            _defaultAbsoluteExpirationRelativeToNow = cacheOptions.DefaultAbsoluteExpirationRelativeToNow;
 
             _tableSet = new Lazy<ITableSet<CachedItem>>(() =>
             {
@@ -221,6 +223,11 @@ namespace DistributedCache.AzureTableStorage.Implementations
                 }
 
                 return options.AbsoluteExpiration.Value;
+            }
+
+            if (_defaultAbsoluteExpirationRelativeToNow.HasValue)
+            {
+                return currentTime.Add(_defaultAbsoluteExpirationRelativeToNow.Value);
             }
 
             throw new NotSupportedException("Only 'AbsoluteExpirationRelativeToNow' and 'AbsoluteExpiration' are supported in Azure Table Storage.");

--- a/src/DistributedCache.AzureTableStorage/Options/AzureTableStorageCacheOptions.cs
+++ b/src/DistributedCache.AzureTableStorage/Options/AzureTableStorageCacheOptions.cs
@@ -20,6 +20,11 @@ namespace DistributedCache.AzureTableStorage.Options
         public TimeSpan? ExpiredItemsDeletionInterval { get; set; }
 
         /// <summary>
+        /// Gets or sets a default absolute expiration time, relative to now.
+        /// </summary>
+        public TimeSpan? DefaultAbsoluteExpirationRelativeToNow { get; set;}
+
+        /// <summary>
         /// Gets or sets the connection string of the storage account.
         /// </summary>
 #pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.


### PR DESCRIPTION
When using DistributedCache.AzureTableStorage to store ADAL Tokens, an exception was raised saying that Azure Table Storage supports only 'AbsoluteExpirationRelativeToNow' and 'AbsoluteExpiration'.

I have added a new property to the option to define a 'DefaultAbsoluteExpirationRelativeToNow' that is used when no 'AbsoluteExpirationRelativeToNow' or 'AbsoluteExpiration' are set to the DistributedCacheEntryOptions instance.

