### PR TITLE
Added error handling for concurrency issue

### DIFF
--- a/src/DistributedCache.AzureTableStorage.V3/Implementations/AzureTableStorageCache.cs
+++ b/src/DistributedCache.AzureTableStorage.V3/Implementations/AzureTableStorageCache.cs
@@ -115,7 +115,6 @@ internal abstract class AzureTableStorageCache : IDistributedCache
 
             try
             {
-                // Use the entity's ETag for optimistic concurrency. This avoids updating if the entity was deleted or changed.
                 await _tableClient
                     .UpdateEntityAsync(item, ETag.All, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);


### PR DESCRIPTION
Adding error handling to the cache item refresh to handle concurrency errors.
https://github.com/StefH/DistributedCache.AzureTableStorage/issues/19

